### PR TITLE
CC-87 Refactor link components to perform immediate navigation

### DIFF
--- a/index.html
+++ b/index.html
@@ -2,9 +2,9 @@
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
-    <link rel="icon" type="image/svg+xml" href="/vite.svg" />
+    <link rel="icon" type="image/svg+xml" href="/logo.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Vite + React + TS</title>
+    <title>CityConnect</title>
   </head>
   <body>
     <div id="app"></div>

--- a/src/components/tripcard.tsx
+++ b/src/components/tripcard.tsx
@@ -14,14 +14,16 @@ interface TripCardProps {
   trip: Trip;
   isLoaded: boolean;
   clickable?: boolean;
+  onClick?: () => void;
 }
 
 export default function TripCard({
   trip,
   isLoaded,
   clickable = true,
+  onClick,
 }: TripCardProps) {
-  const [cookies, setCookies] = useCookies();
+  const [cookies] = useCookies(["currency"]);
 
   return (
     <Skeleton isLoaded={isLoaded} className="rounded-lg overflow-visible">
@@ -31,13 +33,7 @@ export default function TripCard({
         id={"tripCard" + trip.id}
         isPressable={clickable && trip.freeSeats > 0}
         isDisabled={trip.freeSeats === 0}
-        onClick={
-          clickable
-            ? () => {
-                setCookies("trip", trip.id.toString(), { path: "/" });
-              }
-            : undefined
-        }
+        onClick={onClick}
       >
         <CardHeader className="flex flex-col justify-start items-start space-x-80">
           <div className="flex justify-between space-x-4 self-center items-center">

--- a/src/routeTree.gen.ts
+++ b/src/routeTree.gen.ts
@@ -16,18 +16,11 @@ import { Route as rootRoute } from './routes/__root'
 
 // Create Virtual Routes
 
-const AboutLazyImport = createFileRoute('/about')()
 const IndexLazyImport = createFileRoute('/')()
 const ReservationIndexLazyImport = createFileRoute('/reservation/')()
-const TripsPageLazyImport = createFileRoute('/trips/page')()
 const ReservationSuccessLazyImport = createFileRoute('/reservation/success')()
 
 // Create/Update Routes
-
-const AboutLazyRoute = AboutLazyImport.update({
-  path: '/about',
-  getParentRoute: () => rootRoute,
-} as any).lazy(() => import('./routes/about.lazy').then((d) => d.Route))
 
 const IndexLazyRoute = IndexLazyImport.update({
   path: '/',
@@ -61,10 +54,6 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof IndexLazyImport
       parentRoute: typeof rootRoute
     }
-    '/about': {
-      preLoaderRoute: typeof AboutLazyImport
-      parentRoute: typeof rootRoute
-    }
     '/reservation/success': {
       preLoaderRoute: typeof ReservationSuccessLazyImport
       parentRoute: typeof rootRoute
@@ -84,9 +73,7 @@ declare module '@tanstack/react-router' {
 
 export const routeTree = rootRoute.addChildren([
   IndexLazyRoute,
-  AboutLazyRoute,
   ReservationSuccessLazyRoute,
-  TripsPageLazyRoute,
   ReservationIndexLazyRoute,
 ])
 

--- a/src/routeTree.gen.ts
+++ b/src/routeTree.gen.ts
@@ -17,6 +17,7 @@ import { Route as rootRoute } from './routes/__root'
 // Create Virtual Routes
 
 const IndexLazyImport = createFileRoute('/')()
+const TripsIndexLazyImport = createFileRoute('/trips/')()
 const ReservationIndexLazyImport = createFileRoute('/reservation/')()
 const ReservationSuccessLazyImport = createFileRoute('/reservation/success')()
 
@@ -27,17 +28,17 @@ const IndexLazyRoute = IndexLazyImport.update({
   getParentRoute: () => rootRoute,
 } as any).lazy(() => import('./routes/index.lazy').then((d) => d.Route))
 
+const TripsIndexLazyRoute = TripsIndexLazyImport.update({
+  path: '/trips/',
+  getParentRoute: () => rootRoute,
+} as any).lazy(() => import('./routes/trips/index.lazy').then((d) => d.Route))
+
 const ReservationIndexLazyRoute = ReservationIndexLazyImport.update({
   path: '/reservation/',
   getParentRoute: () => rootRoute,
 } as any).lazy(() =>
   import('./routes/reservation/index.lazy').then((d) => d.Route),
 )
-
-const TripsPageLazyRoute = TripsPageLazyImport.update({
-  path: '/trips/page',
-  getParentRoute: () => rootRoute,
-} as any).lazy(() => import('./routes/trips/page.lazy').then((d) => d.Route))
 
 const ReservationSuccessLazyRoute = ReservationSuccessLazyImport.update({
   path: '/reservation/success',
@@ -58,12 +59,12 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof ReservationSuccessLazyImport
       parentRoute: typeof rootRoute
     }
-    '/trips/page': {
-      preLoaderRoute: typeof TripsPageLazyImport
-      parentRoute: typeof rootRoute
-    }
     '/reservation/': {
       preLoaderRoute: typeof ReservationIndexLazyImport
+      parentRoute: typeof rootRoute
+    }
+    '/trips/': {
+      preLoaderRoute: typeof TripsIndexLazyImport
       parentRoute: typeof rootRoute
     }
   }
@@ -75,6 +76,7 @@ export const routeTree = rootRoute.addChildren([
   IndexLazyRoute,
   ReservationSuccessLazyRoute,
   ReservationIndexLazyRoute,
+  TripsIndexLazyRoute,
 ])
 
 /* prettier-ignore-end */

--- a/src/routes/about.lazy.tsx
+++ b/src/routes/about.lazy.tsx
@@ -1,9 +1,0 @@
-import { createLazyFileRoute } from "@tanstack/react-router";
-
-export const Route = createLazyFileRoute("/about")({
-  component: About,
-});
-
-function About() {
-  return <div className="p-2">Hello from About!</div>;
-}

--- a/src/routes/index.lazy.tsx
+++ b/src/routes/index.lazy.tsx
@@ -4,8 +4,8 @@ import {
   Autocomplete,
   AutocompleteItem,
 } from "@nextui-org/react";
-import { Link, createLazyFileRoute } from "@tanstack/react-router";
-import { useEffect, useState } from "react";
+import { createLazyFileRoute, useNavigate } from "@tanstack/react-router";
+import { useState } from "react";
 import { NavbarClient } from "@/components/navbar";
 import { useQuery } from "@tanstack/react-query";
 import { City } from "@/types/city";
@@ -17,42 +17,49 @@ export const Route = createLazyFileRoute("/")({
 });
 
 function Index() {
-  const [, setCookie] = useCookies();
+  const navigate = useNavigate();
+
+  const [, setCookie] = useCookies([
+    "departure",
+    "arrival",
+    "departureTime",
+    "currency",
+  ]);
+
   const [departure, setDeparture] = useState<number>(0);
   const [arrival, setArrival] = useState<number>(0);
   const [departureTime, setDepartureTime] = useState<string>(
     new Date().toISOString().substring(0, 10)
   );
-  const [searchEnabled, setSearchEnabled] = useState<boolean>(false);
-  const isFormValid = () => {
-    return departure !== 0 && arrival !== 0 && departureTime !== "";
-  };
+
+  const isFormValid = departure !== 0 && arrival !== 0 && departureTime !== "";
+
   const handleDepartureChange = (value: { toString: () => string }) => {
     const departureId = value ? parseInt(value.toString()) : 0;
     setDeparture(departureId);
   };
+
   const handleArrivalChange = (value: { toString: () => string }) => {
     const arrivalId = value ? parseInt(value.toString()) : 0;
     setArrival(arrivalId);
   };
+
   const handleSearch = () => {
-    if (searchEnabled) {
-      setCookie("departure", departure.toString());
-      setCookie("arrival", arrival.toString());
-      setCookie("departureTime", departureTime);
-      setCookie("currency", "EUR");
-    } else {
-      alert("Please select a departure and arrival city.");
-    }
+    setCookie("departure", departure.toString());
+    setCookie("arrival", arrival.toString());
+    setCookie("departureTime", departureTime);
+    setCookie("currency", "EUR");
+
+    void navigate({
+      to: "/trips",
+      search: { departure, arrival, departureTime },
+    });
   };
+
   const { data: cities } = useQuery<City[]>({
     queryKey: ["cities"],
     queryFn: () => getCities(),
   });
-
-  useEffect(() => {
-    setSearchEnabled(departure !== 0 && arrival !== 0);
-  }, [departure, arrival]);
 
   return (
     <div className="p-2 h-screen flex flex-col">
@@ -109,28 +116,15 @@ function Index() {
               granularity="day"
               onChange={(date) => setDepartureTime(date.toString())}
             />
-            <Link
-              to={searchEnabled ? "/trips" : ""}
-              search={
-                searchEnabled
-                  ? {
-                      departure: departure,
-                      arrival: arrival,
-                      departureTime: departureTime,
-                    }
-                  : {}
-              }
+            <Button
+              color="primary"
+              size="lg"
+              className="h-14"
+              isDisabled={!isFormValid}
+              onClick={handleSearch}
             >
-              <Button
-                color="primary"
-                size="lg"
-                className="h-14"
-                isDisabled={!isFormValid()}
-                onClick={handleSearch}
-              >
-                Search
-              </Button>
-            </Link>
+              Search
+            </Button>
           </div>
         </div>
       </div>

--- a/src/routes/index.lazy.tsx
+++ b/src/routes/index.lazy.tsx
@@ -27,11 +27,11 @@ function Index() {
   const isFormValid = () => {
     return departure !== 0 && arrival !== 0 && departureTime !== "";
   };
-  const handleDepartureChange = (value: { toString: () => string; }) => {
+  const handleDepartureChange = (value: { toString: () => string }) => {
     const departureId = value ? parseInt(value.toString()) : 0;
     setDeparture(departureId);
   };
-  const handleArrivalChange = (value: { toString: () => string; }) => {
+  const handleArrivalChange = (value: { toString: () => string }) => {
     const arrivalId = value ? parseInt(value.toString()) : 0;
     setArrival(arrivalId);
   };
@@ -110,7 +110,7 @@ function Index() {
               onChange={(date) => setDepartureTime(date.toString())}
             />
             <Link
-              to={searchEnabled ? "/trips/page" : ""}
+              to={searchEnabled ? "/trips" : ""}
               search={
                 searchEnabled
                   ? {

--- a/src/routes/trips/index.lazy.tsx
+++ b/src/routes/trips/index.lazy.tsx
@@ -10,7 +10,7 @@ import { City } from "@/types/city";
 import { useQuery } from "@tanstack/react-query";
 import { getCities } from "@/service/cityService";
 import { useState } from "react";
-import { Link, createFileRoute, useNavigate } from "@tanstack/react-router";
+import { createFileRoute, useNavigate } from "@tanstack/react-router";
 import { NavbarClient } from "@/components/navbar";
 import { getTrips } from "@/service/tripService";
 import TripCard from "@/components/tripcard";
@@ -60,10 +60,10 @@ export default function Trips() {
       stateTemp.departureTime = new Date().toISOString().split("T")[0];
     }
 
-    void navigate({ to: "/trips", search: stateTemp, replace: true });
+    void navigate({ search: stateTemp, replace: true });
   }
 
-  const [cookies] = useCookies();
+  const [cookies, setCookies] = useCookies(["currency", "trip"]);
   const currency = (cookies.currency as Currency) ?? "EUR";
   const [seats, setSeats] = useState<number>(1);
   const [state, setState] = useState({
@@ -73,10 +73,7 @@ export default function Trips() {
   });
 
   const updateParameters = () => {
-    const queryString = new URLSearchParams(
-      state as unknown as Record<string, string>
-    ).toString();
-    void navigate({ search: queryString });
+    void navigate({ search: state, replace: true });
   };
 
   const setArrival = (value: number) =>
@@ -198,16 +195,14 @@ export default function Trips() {
                   : undefined
               }
             />
-            <Link search={state}>
-              <Button
-                color="primary"
-                size="lg"
-                className="h-14 w-full"
-                onClick={updateParameters}
-              >
-                Search
-              </Button>
-            </Link>
+            <Button
+              color="primary"
+              size="lg"
+              className="h-14 w-full"
+              onClick={updateParameters}
+            >
+              Search
+            </Button>
           </div>
         </div>
         {isTripsPending ? (
@@ -220,13 +215,17 @@ export default function Trips() {
             {trips?.length !== 0 ? (
               <div className="grid px-4 grid-cols-1 md:grid-cols-2 lg:grid-cols-2 lg:gap-y-16 md:px-8 gap-12">
                 {trips?.map((trip) => (
-                  <Link
+                  <TripCard
                     key={trip.id}
-                    to={`/reservation`}
-                    className="overflow-visible"
-                  >
-                    <TripCard isLoaded={!isTripsPending} trip={trip} />
-                  </Link>
+                    isLoaded={!isTripsPending}
+                    trip={trip}
+                    onClick={() => {
+                      setCookies("trip", trip.id.toString(), { path: "/" });
+                      void navigate({
+                        to: "/reservation",
+                      });
+                    }}
+                  />
                 ))}
               </div>
             ) : (

--- a/src/routes/trips/index.lazy.tsx
+++ b/src/routes/trips/index.lazy.tsx
@@ -24,7 +24,7 @@ interface TripInfo {
   departureTime: string;
 }
 
-export const Route = createFileRoute("/trips/page")({
+export const Route = createFileRoute("/trips/")({
   validateSearch: (search: Record<string, unknown>): TripInfo => {
     return {
       departure: search.departure as number,
@@ -60,7 +60,7 @@ export default function Trips() {
       stateTemp.departureTime = new Date().toISOString().split("T")[0];
     }
 
-    void navigate({ to: "/trips/page", search: stateTemp, replace: true });
+    void navigate({ to: "/trips", search: stateTemp, replace: true });
   }
 
   const [cookies] = useCookies();


### PR DESCRIPTION
# What's changed
[Tanstack Router](https://tanstack.com/router/latest)'s `<Link>` component renders an actual `<a>` HTML tag, which triggers a full reload of the app and thus it's against React's philosophy. This PR changes this behavior to use the Tanstack Router's `useNavigate` hook, to perform an immediate, no-reload client-side navigation.

## Other changes
 - `<head>` logo change, from default Vite to CityConnect one
 - Cookie types
 - Some code abstractions
 - Remove useless `/about` page
 - Change trips page link from `/trips/page` to `/trips`